### PR TITLE
Update images to latest releases

### DIFF
--- a/build/Dockerfile.image-cache-controller
+++ b/build/Dockerfile.image-cache-controller
@@ -1,4 +1,4 @@
-FROM 689494258501.dkr.ecr.us-east-1.amazonaws.com/elotl/image-cache-controller:v1.0.0 AS base
+FROM 689494258501.dkr.ecr.us-east-1.amazonaws.com/elotl-dev/image-cache-controller:v1.0.0 AS base
 
 FROM amazonlinux
 

--- a/build/Dockerfile.init-cert
+++ b/build/Dockerfile.init-cert
@@ -1,4 +1,4 @@
-FROM elotl/init-cert:v1.0.0 AS base
+FROM elotl/init-cert:v1.0.2 AS base
 
 FROM amazonlinux:latest
 

--- a/build/Dockerfile.kip
+++ b/build/Dockerfile.kip
@@ -1,4 +1,4 @@
-FROM elotl/kip:v1.0.0 AS base
+FROM elotl/kip:v1.0.2 AS base
 
 FROM amazonlinux:latest
 

--- a/build/Dockerfile.kip-aws-meteringagent
+++ b/build/Dockerfile.kip-aws-meteringagent
@@ -1,7 +1,8 @@
-FROM 689494258501.dkr.ecr.us-east-1.amazonaws.com/elotl/kip-aws-meteringagent:v1.0.1 AS base
+FROM 689494258501.dkr.ecr.us-east-1.amazonaws.com/elotl-dev/kip-aws-meteringagent:v1.0.3 AS base
 
 FROM amazonlinux
 
+ENV PRODUCT_CODE=9iyga48767smc3nbdqo31qq5c
 ENV PUBLIC_KEY_VERSION=1
 
 COPY --from=base /kip-aws-meteringagent /

--- a/kustomize/patch-provider-statefulset.yaml
+++ b/kustomize/patch-provider-statefulset.yaml
@@ -28,8 +28,6 @@
     - --stats-endpoint=http://$(POD_NAME):10255/stats
     - --pods-endpoint=https://$(POD_NAME):10250/runningpods
     env:
-    - name: PRODUCT_CODE
-      value: 9iyga48767smc3nbdqo31qq5c
     - name: AWS_SDK_LOAD_CONFIG
       value: "1"
     - name: CLUSTER_NAME


### PR DESCRIPTION
This will update images to their latest released version.

Notes:
- For image-cache-controller and kip-aws-meteringagent, I created new repos as their default repo where their builds pushes container images to. This way, we can keep the default image repo and the staging repo separate (staging is used for submitting images to the marketplace).
- I moved back `PRODUCT_CODE` to the kip-aws-meteringagent image as a default environment variable. This way there is less of a chance that a user accidentally removes it or changes it and thus disables metering.

I plan to tag this as `v1.0.1` once merged.