### PR TITLE
Update kip-aws-meteringagent

### DIFF
--- a/build/Dockerfile.kip-aws-meteringagent
+++ b/build/Dockerfile.kip-aws-meteringagent
@@ -1,4 +1,4 @@
-FROM 689494258501.dkr.ecr.us-east-1.amazonaws.com/elotl-dev/kip-aws-meteringagent:v1.0.3 AS base
+FROM 689494258501.dkr.ecr.us-east-1.amazonaws.com/elotl-dev/kip-aws-meteringagent:v1.0.4 AS base
 
 FROM amazonlinux
 


### PR DESCRIPTION
Just looping everyone in - we use staging repos for our container images at `REGISTRY:-689494258501.dkr.ecr.us-east-1.amazonaws.com/elotl/<project>`. When releasing a new version, we tag all of them in lockstep, to make sure that the same tag always refers to a group of images that were tested together.